### PR TITLE
Add support for C++11 type alias with using keyword

### DIFF
--- a/Test/using.cpp
+++ b/Test/using.cpp
@@ -1,0 +1,4 @@
+using Integer = int;
+
+template <typename T>
+using Vector = std::vector<T>;

--- a/c.c
+++ b/c.c
@@ -149,6 +149,7 @@ typedef enum eDeclaration {
 	DECL_STRUCT,
 	DECL_TASK,           /* Vera task */
 	DECL_UNION,
+	DECL_USING,
 	DECL_COUNT
 } declType;
 
@@ -1274,6 +1275,8 @@ static void qualifyVariableTag (const statementInfo *const st,
 				TAG_EVENT);
 	else if (st->declaration == DECL_PACKAGE)
 		makeTag (nameToken, st, FALSE, TAG_PACKAGE);
+	else if (st->declaration == DECL_USING && st->assignment)
+		makeTag (nameToken, st, TRUE, TAG_TYPEDEF);
 	else if (isValidTypeSpecifier (st->declaration))
 	{
 		if (st->notVariable)
@@ -1757,7 +1760,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_THROWS:    discardTypeList (token);                break;
 		case KEYWORD_UNION:     st->declaration = DECL_UNION;           break;
 		case KEYWORD_UNSIGNED:  st->declaration = DECL_BASE;            break;
-		case KEYWORD_USING:     skipStatement (st);                     break;
+		case KEYWORD_USING:     st->declaration = DECL_USING;           break;
 		case KEYWORD_VOID:      st->declaration = DECL_BASE;            break;
 		case KEYWORD_VOLATILE:  st->declaration = DECL_BASE;            break;
 		case KEYWORD_VIRTUAL:   st->implementation = IMP_VIRTUAL;       break;


### PR DESCRIPTION
Hello,

C++11 introduced the "using name = type;" construct as an alternative to typedefs. Process them as typedefs.

Cheers,

Maxime Coste.
