### PR TITLE
Robot: accept regex in embedded arguments

### DIFF
--- a/parsers/robot.c
+++ b/parsers/robot.c
@@ -144,7 +144,7 @@ static void initialize (const langType language)
 
     addLanguageCallbackRegex (
 		language,
-		"(^([A-Za-z0-9]+|\\$\\{[_A-Za-z0-9][' _A-Za-z0-9]+\\})([${}' _][-${}A-Za-z0-9]+)*)",
+		"(^([A-Za-z0-9]+|\\$\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\|)+)*\\})([${}' _]([-_$A-Za-z0-9]+|\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\|)+)*\\})+)*)",
 		"{exclusive}", tagKeywordsAndTestCases, NULL, NULL);
 
     addLanguageCallbackRegex (language, "^[$@]\\{([_A-Za-z0-9][' _A-Za-z0-9]+)\\}  [ ]*.+",


### PR DESCRIPTION
Possible solution to Robot keywords containing regex in embedded arguments.
I tested it with a large project I'm working on; I hope I didn't miss any corner case.