### PR TITLE
CXX: Simplify the extraction of default strings in signatures

### DIFF
--- a/Units/parser-cxx.r/signature.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/signature.cpp.d/expected.tags
@@ -2,3 +2,9 @@ BAR::bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:B
 bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char * c,double d[]) const
 foo	input.cpp	/^void foo (int a, char b) {}$/;"	f	typeref:typename:void	signature:(int a,char b)
 foobar	input.cpp	/^void foobar __ARGS ((int a, char b));$/;"	p	typeref:typename:void	file:	signature:(int a,char b)
+params1	input.cpp	/^void params1(const char * c = "blah");$/;"	p	typeref:typename:void	file:	signature:(const char * c="blah")
+params2	input.cpp	/^void params2(char x = 'x');$/;"	p	typeref:typename:void	file:	signature:(char x='x')
+params3	input.cpp	/^void params3(char x = ' ');$/;"	p	typeref:typename:void	file:	signature:(char x=' ')
+params4	input.cpp	/^void params4(char x = ',');$/;"	p	typeref:typename:void	file:	signature:(char x=',')
+params5	input.cpp	/^void params5(char x = '\\n');$/;"	p	typeref:typename:void	file:	signature:(char x='\\n')
+params6	input.cpp	/^void params6(char x = '\\t',int n = 10,const char * v = "a string with\\na newline");/;"	p	typeref:typename:void	file:	signature:(char x='\\t',int n=10,const char * v="a string with\\na newline")

--- a/Units/parser-cxx.r/signature.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/signature.cpp.d/input.cpp
@@ -8,3 +8,11 @@ void foo (int a, char b) {}
 char *BAR::bar (char *c, double d[]) const {}
 
 void foobar __ARGS ((int a, char b));
+
+
+void params1(const char * c = "blah");
+void params2(char x = 'x');
+void params3(char x = ' ');
+void params4(char x = ',');
+void params5(char x = '\n');
+void params6(char x = '\t',int n = 10,const char * v = "a string with\na newline");

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -77,6 +77,9 @@ typedef struct sCppState {
 	int * ungetPointer;      /* the current unget char: points in the middle of the buffer */
 	int ungetDataSize;        /* the number of valid unget characters in the buffer */
 
+	/* the contents of the last SYMBOL_CHAR or SYMBOL_STRING */
+	vString * charOrStringContents;
+
 	bool resolveRequired;     /* must resolve if/else/elif/endif branch */
 	bool hasAtLiteralStrings; /* supports @"c:\" strings */
 	bool hasCxxRawLiteralStrings; /* supports R"xxx(...)xxx" strings */
@@ -169,6 +172,7 @@ static cppState Cpp = {
 	.ungetBufferSize = 0,
 	.ungetPointer = NULL,
 	.ungetDataSize = 0,
+	.charOrStringContents = NULL,
 	.resolveRequired = false,
 	.hasAtLiteralStrings = false,
 	.hasCxxRawLiteralStrings = false,
@@ -236,6 +240,9 @@ static void cppInitCommon(langType clientLang,
 	Cpp.clientLang = clientLang;
 	Cpp.ungetBuffer = NULL;
 	Cpp.ungetPointer = NULL;
+
+	CXX_DEBUG_ASSERT(!Cpp.charOrStringContents,"This string should be null when CPP is not initialized");
+	Cpp.charOrStringContents = vStringNew();
 
 	Cpp.resolveRequired = false;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
@@ -314,6 +321,12 @@ extern void cppTerminate (void)
 	{
 		eFree(Cpp.ungetBuffer);
 		Cpp.ungetBuffer = NULL;
+	}
+
+	if(Cpp.charOrStringContents)
+	{
+		vStringDelete(Cpp.charOrStringContents);
+		Cpp.charOrStringContents = NULL;
 	}
 
 	Cpp.clientLang = LANG_IGNORE;
@@ -982,27 +995,34 @@ static int skipOverDComment (void)
 	return c;
 }
 
+const vString * cppGetLastCharOrStringContents (void)
+{
+	CXX_DEBUG_ASSERT(Cpp.charOrStringContents,"Shouldn't be called when CPP is not initialized");
+	return Cpp.charOrStringContents;
+}
+
 /*  Skips to the end of a string, returning a special character to
  *  symbolically represent a generic string.
  */
-static int skipToEndOfString (bool ignoreBackslash, vString *rawdata, unsigned int maxlen)
+static int skipToEndOfString (bool ignoreBackslash)
 {
 	int c;
+
+	vStringClear(Cpp.charOrStringContents);
 
 	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 		if (c == BACKSLASH && ! ignoreBackslash)
 		{
-			if (rawdata)
-				vStringPutWithLimit (rawdata, c, maxlen);
+			vStringPutWithLimit (Cpp.charOrStringContents, c, 1024);
 			c = cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
-			if ((c != EOF) && rawdata)
-				vStringPutWithLimit (rawdata, c, maxlen);
+			if (c != EOF)
+				vStringPutWithLimit (Cpp.charOrStringContents, c, 1024);
 		}
 		else if (c == DOUBLE_QUOTE)
 			break;
-		else if (rawdata)
-			vStringPutWithLimit (rawdata, c, maxlen);
+		else
+			vStringPutWithLimit (Cpp.charOrStringContents, c, 1024);
 	}
 	return STRING_SYMBOL;  /* symbolic representation of string */
 }
@@ -1020,7 +1040,7 @@ static int skipToEndOfCxxRawLiteralString (void)
 	if (c != '(' && ! isCxxRawLiteralDelimiterChar (c))
 	{
 		cppUngetc (c);
-		c = skipToEndOfString (false, NULL, 0);
+		c = skipToEndOfString (false);
 	}
 	else
 	{
@@ -1060,21 +1080,22 @@ static int skipToEndOfCxxRawLiteralString (void)
  *  special character to symbolically represent a generic character.
  *  Also detects Vera numbers that include a base specifier (ie. 'b1010).
  */
-static int skipToEndOfChar (vString *rawdata, unsigned int maxlen)
+static int skipToEndOfChar ()
 {
 	int c;
 	int count = 0, veraBase = '\0';
+
+	vStringClear(Cpp.charOrStringContents);
 
 	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 	    ++count;
 		if (c == BACKSLASH)
 		{
-			if (rawdata)
-				vStringPutWithLimit (rawdata, c, maxlen);
+			vStringPutWithLimit (Cpp.charOrStringContents, c, 10);
 			c = cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
-			if ((c != EOF) && rawdata)
-				vStringPutWithLimit (rawdata, c, maxlen);
+			if (c != EOF)
+				vStringPutWithLimit (Cpp.charOrStringContents, c, 10);
 		}
 		else if (c == SINGLE_QUOTE)
 			break;
@@ -1088,18 +1109,18 @@ static int skipToEndOfChar (vString *rawdata, unsigned int maxlen)
 			if (count == 1  &&  strchr ("DHOB", toupper (c)) != NULL)
 			{
 				veraBase = c;
-				vStringPutWithLimit (rawdata, c, maxlen);
+				vStringPutWithLimit (Cpp.charOrStringContents, c, 10);
 			}
 			else if (veraBase != '\0'  &&  ! isalnum (c))
 			{
 				cppUngetc (c);
 				break;
 			}
-			else if (rawdata)
-				vStringPutWithLimit (rawdata, c, maxlen);
+			else
+				vStringPutWithLimit (Cpp.charOrStringContents, c, 10);
 		}
-		else if (rawdata)
-			vStringPutWithLimit (rawdata, c, maxlen);
+		else
+			vStringPutWithLimit (Cpp.charOrStringContents, c, 10);
 	}
 	return CHAR_SYMBOL;  /* symbolic representation of character */
 }
@@ -1122,11 +1143,6 @@ static void attachEndFieldMaybe (int macroCorkIndex)
  *  the tokenizer.
  */
 extern int cppGetc (void)
-{
-	return cppGetcFull (NULL, 0);
-}
-
-extern int cppGetcFull (vString *rawData, int maxlen)
 {
 	bool directive = false;
 	bool ignore = false;
@@ -1167,7 +1183,7 @@ process:
 				else
 				{
 					Cpp.directive.accept = false;
-					c = skipToEndOfString (false, rawData, maxlen);
+					c = skipToEndOfString (false);
 				}
 
 				break;
@@ -1183,7 +1199,7 @@ process:
 
 			case SINGLE_QUOTE:
 				Cpp.directive.accept = false;
-				c = skipToEndOfChar (rawData, maxlen);
+				c = skipToEndOfChar ();
 				break;
 
 			case '/':
@@ -1318,7 +1334,7 @@ process:
 					if (next == DOUBLE_QUOTE)
 					{
 						Cpp.directive.accept = false;
-						c = skipToEndOfString (true, NULL, 0);
+						c = skipToEndOfString (true);
 						break;
 					}
 					else

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -90,6 +90,7 @@ extern void cppUngetc (const int c);
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern int cppGetcFull (vString *rawData, int maxlen);
+extern const vString * cppGetLastCharOrStringContents (void);
 
 /* notify the external parser state for the purpose of conditional
    branch choice. The CXX parser stores the block level here. */

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -89,7 +89,6 @@ extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
-extern int cppGetcFull (vString *rawData, int maxlen);
 extern const vString * cppGetLastCharOrStringContents (void);
 
 /* notify the external parser state for the purpose of conditional

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -26,18 +26,10 @@
 
 #define UINFO(c) (((c) < 0x80 && (c) >= 0) ? g_aCharTable[c].uType : 0)
 
-static void cxxParserSkipToNonWhiteSpaceFull(vString *pRawdata, unsigned int uMaxlen)
-{
-	if(!cppIsspace(g_cxx.iChar))
-		return;
-	do
-		g_cxx.iChar = cppGetcFull(pRawdata, uMaxlen);
-	while(cppIsspace(g_cxx.iChar));
-}
-
 static void cxxParserSkipToNonWhiteSpace(void)
 {
-	cxxParserSkipToNonWhiteSpaceFull (NULL, 0);
+	while(cppIsspace(g_cxx.iChar))
+		g_cxx.iChar = cppGetc();
 }
 
 enum CXXCharType
@@ -1154,14 +1146,12 @@ bool cxxParserParseNextToken(void)
 	}
 
 	CXXToken * t = cxxTokenCreate();
-	static vString *pRawdata;
-	pRawdata = vStringNewOrClear (pRawdata);
 
 	cxxTokenChainAppend(g_cxx.pTokenChain,t);
 
 	g_cxx.pToken = t;
 
-	cxxParserSkipToNonWhiteSpaceFull(pRawdata, 0);
+	cxxParserSkipToNonWhiteSpace();
 
 	// FIXME: this cpp handling is kind of broken:
 	// it works only because the moon is in the correct phase.
@@ -1373,7 +1363,7 @@ bool cxxParserParseNextToken(void)
 	{
 		t->eType = CXXTokenTypeStringConstant;
 		vStringPut(t->pszWord,'"');
-		vStringCat(t->pszWord, pRawdata);
+		vStringCat(t->pszWord,cppGetLastCharOrStringContents());
 		vStringPut(t->pszWord,'"');
 		g_cxx.iChar = cppGetc();
 		t->bFollowedBySpace = cppIsspace(g_cxx.iChar);
@@ -1421,7 +1411,7 @@ bool cxxParserParseNextToken(void)
 	{
 		t->eType = CXXTokenTypeCharacterConstant;
 		vStringPut(t->pszWord,'\'');
-		vStringCat(t->pszWord, pRawdata);
+		vStringCat(t->pszWord,cppGetLastCharOrStringContents());
 		vStringPut(t->pszWord,'\'');
 		g_cxx.iChar = cppGetc();
 		t->bFollowedBySpace = cppIsspace(g_cxx.iChar);


### PR DESCRIPTION
Move the (previously global static) char/string contents buffer to a preprocessor global so the whole code path leading to it is simplified and usage is limited to the char/string case.
Also add tests.